### PR TITLE
Callback beforeOpen to execute code before showing menu

### DIFF
--- a/jquery.contextmenu.js
+++ b/jquery.contextmenu.js
@@ -57,7 +57,7 @@ jQuery.fn.contextPopup = function(menuData) {
         }
         row.find('span').text(item.label);
         if (item.action) {
-          row.find('a').click(function(){ item.action(e); });
+          row.find('a').click(function(){ item.action(e); return false; });
         }
       } else {
         $('<li class="' + settings.seperatorClass + '"></li>').appendTo(menu);


### PR DESCRIPTION
This adds a callback which can be provided with:

$("#whatever").contextPopup({
    beforeOpen : function(e) {
        // Content
    },
    items: [
        // ...
    ]
});

This is very useful in situation where you want to change something before actually showing the menu. For example I use it to select a table row (i.e. paint it orange) before showing the menu for it.
