### PR TITLE
Several Changes / Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Include the files `jquery.contextmenu.css` and `jquery.contextmenu.js` in your p
     <!DOCTYPE html>
     <html>
       <head>
-         <script src="jquery-1.6.2.min.js"></script> 
+         <script src="[some Path To Modern jQuery]"></script>
          <script src="jquery.contextmenu.js"></script> 
          <link rel="stylesheet" href="jquery.contextmenu.css">
          ... rest of your stuff ...
@@ -61,7 +61,13 @@ You can wire up a context menu like this:
         {label:'Another Thing', icon:'icons/receipt-text.png',    action:function() { alert('clicked 2') } },
         null, /* null can be used to add a separator to the menu items */
         {label:'Blah Blah',     icon:'icons/book-open-list.png',  action:function() { alert('clicked 3') }, isEnabled:function() { return false; } },
-      ]});
+      ],
+      dataTokenLookups: [
+        'name-of-data-attribute-to-retrieve-from-bound-element-and-placed-on-items[0]',
+        'name-of-data-attribute-to-retrieve-from-bound-element-and-placed-on-items[1]',
+        'name-of-data-attribute-to-retrieve-from-bound-element-and-placed-on-items[2]',
+        ]
+      });
 
 The 'isEnabled' function is optional.  By default all items are enabled.
 
@@ -71,10 +77,17 @@ Icons
 The icons should be 16x16 pixels. I recommend the [Fugue icon set](http://p.yusukekamiyamane.com/) (shadowless).
 
 
-kthxbye
 
--[joe](http://joewalnes.com)
+CHANGES FROM ORIGINAL
+-----------------------
 
+- can now specify the tag type that the clickable context-menu element should be.
+Defaults to <span> instead of <a>, since clicks don't necessarily take someone to a new resource/URI
 
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/joewalnes/jquery-simple-context-menu/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+- class 'linkClicker' given to that clickable element, which allows for more accurate styling
+ as well as DOM node traversal when building the menu (no need to rely on specific tags in a specific order; classes are more flexible)
 
+- ability to take "data-" attributes from the original target / the element the context-menu is bound to
+ and have it associated with the clickable context-menu element
+
+- update jQuery methods / replaced .bind() with .on()

--- a/demo/example.html
+++ b/demo/example.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="http://code.jquery.com/jquery-1.6.2.min.js"></script>
+    <script src="http://code.jquery.com/jquery-1.11.2.min.js"></script>
     <script src="../jquery.contextmenu.js"></script>
     <link rel="stylesheet" href="../jquery.contextmenu.css">
     <script>

--- a/jquery.contextmenu.css
+++ b/jquery.contextmenu.css
@@ -22,7 +22,7 @@
   background-repeat: no-repeat;
 }
 
-.contextMenuPlugin > li > a {
+.contextMenuPlugin > li > .linkClicker {
   position: relative;
   display: block;
   padding: 3px 3px 3px 28px;
@@ -31,14 +31,14 @@
   margin: 1px;
 }
 
-.contextMenuPlugin > li > a img {
+.contextMenuPlugin > li > .linkClicker img {
   position: absolute;
   left: 3px;
   margin-top: -2px;
   width: 16px;
   height: 16px;
 }
-.contextMenuPlugin > li > a:hover {
+.contextMenuPlugin > li > .linkClicker:hover {
   border: 1px solid #fffbff;
   outline: 1px solid #b5d3ff;
   margin: 0;
@@ -56,11 +56,11 @@
   pointer-events: none;
 }
 
-.contextMenuPlugin > li.disabled a {
+.contextMenuPlugin > li.disabled .linkClicker {
   color: grey;
 }
 
-.contextMenuPlugin > li.disabled > a:hover {
+.contextMenuPlugin > li.disabled > .linkClicker:hover {
   border: none;
   outline: none;
 }

--- a/jquery.contextmenu.js
+++ b/jquery.contextmenu.js
@@ -60,7 +60,7 @@ jQuery.fn.contextPopup = function(menuData) {
         if (item.isEnabled != undefined && !item.isEnabled()) {
             row.addClass('disabled');
         } else if (item.action) {
-            row.find('a').click(function () { item.action(e); });
+            row.find('a').on('click',function () { item.action(e); });
         }
 
       } else {
@@ -72,7 +72,7 @@ jQuery.fn.contextPopup = function(menuData) {
   }
 
   // On contextmenu event (right click)
-  this.bind('contextmenu', function(e) {	
+  this.on('contextmenu', function(e) {
     var menu = createMenu(e)
       .show();
     
@@ -87,13 +87,13 @@ jQuery.fn.contextPopup = function(menuData) {
 
     // Create and show menu
     menu.css({zIndex:1000001, left:left, top:top})
-      .bind('contextmenu', function() { return false; });
+      .on('contextmenu', function() { return false; });
 
     // Cover rest of page with invisible div that when clicked will cancel the popup.
     var bg = $('<div></div>')
       .css({left:0, top:0, width:'100%', height:'100%', position:'absolute', zIndex:1000000})
       .appendTo(document.body)
-      .bind('contextmenu click', function() {
+      .on('contextmenu click', function() {
         // If click or right click anywhere else on page: remove clean up.
         bg.remove();
         menu.remove();


### PR DESCRIPTION
- can now specify the tag type that the clickable context-menu element should be. Defaults to SPAN instead of A, since clicks don't necessarily take someone to a new resource/URI

- class 'linkClicker' given to that clickable element, which allows for more accurate styling as well as DOM node traversal when building the menu (no need to rely on specific tags in a specific order; classes are more flexible)

- ability to take "data-" attributes from the original target / the element the context-menu is bound to and have it associated with the clickable context-menu element

- update jQuery methods / replaced .bind() with .on()

- didn't touch any css manipulation/style manipulation ; presumably that can be refactored too at some point


(I'm unfamiliar with the polite way to fork/best practices... please replace any of your credits where they should be, in case I removed them?  thanks--- great plugin to fork)